### PR TITLE
修复INS_task中状态机问题

### DIFF
--- a/17.chassis_task/application/INS_task.c
+++ b/17.chassis_task/application/INS_task.c
@@ -222,9 +222,9 @@ void INS_task(void const *pvParameters)
         }
 
 
-        if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
+        if(gyro_update_flag & (1 << IMU_NOTIFY_SHFITS))
         {
-            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag &= ~(1 << IMU_NOTIFY_SHFITS);
             BMI088_gyro_read_over(gyro_dma_rx_buf + BMI088_GYRO_RX_BUF_DATA_OFFSET, bmi088_real_data.gyro);
         }
 
@@ -646,6 +646,8 @@ void DMA2_Stream2_IRQHandler(void)
 
         if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
         {
+            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag |= (1 << IMU_NOTIFY_SHFITS);
             __HAL_GPIO_EXTI_GENERATE_SWIT(GPIO_PIN_0);
         }
     }

--- a/17.chassis_task/application/INS_task.h
+++ b/17.chassis_task/application/INS_task.h
@@ -33,7 +33,8 @@
 
 #define IMU_DR_SHFITS        0
 #define IMU_SPI_SHFITS       1
-#define IMU_UPDATE_SHFITS        2
+#define IMU_UPDATE_SHFITS    2
+#define IMU_NOTIFY_SHFITS    3
 
 
 #define BMI088_GYRO_RX_BUF_DATA_OFFSET  1

--- a/18.ins_task/application/INS_task.c
+++ b/18.ins_task/application/INS_task.c
@@ -161,9 +161,9 @@ void INS_task(void const *pvParameters)
         }
 
 
-        if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
+        if(gyro_update_flag & (1 << IMU_NOTIFY_SHFITS))
         {
-            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag &= ~(1 << IMU_NOTIFY_SHFITS);
             BMI088_gyro_read_over(gyro_dma_rx_buf + BMI088_GYRO_RX_BUF_DATA_OFFSET, bmi088_real_data.gyro);
         }
 
@@ -392,6 +392,8 @@ void DMA2_Stream2_IRQHandler(void)
 
         if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
         {
+            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag |= (1 << IMU_NOTIFY_SHFITS);
             __HAL_GPIO_EXTI_GENERATE_SWIT(GPIO_PIN_0);
         }
     }

--- a/18.ins_task/application/INS_task.h
+++ b/18.ins_task/application/INS_task.h
@@ -33,7 +33,8 @@
 
 #define IMU_DR_SHFITS        0
 #define IMU_SPI_SHFITS       1
-#define IMU_UPDATE_SHFITS        2
+#define IMU_UPDATE_SHFITS    2
+#define IMU_NOTIFY_SHFITS    3
 
 
 #define BMI088_GYRO_RX_BUF_DATA_OFFSET  1

--- a/19.gimbal_task/application/INS_task.c
+++ b/19.gimbal_task/application/INS_task.c
@@ -222,9 +222,9 @@ void INS_task(void const *pvParameters)
         }
 
 
-        if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
+        if(gyro_update_flag & (1 << IMU_NOTIFY_SHFITS))
         {
-            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag &= ~(1 << IMU_NOTIFY_SHFITS);
             BMI088_gyro_read_over(gyro_dma_rx_buf + BMI088_GYRO_RX_BUF_DATA_OFFSET, bmi088_real_data.gyro);
         }
 
@@ -646,6 +646,8 @@ void DMA2_Stream2_IRQHandler(void)
 
         if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
         {
+            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag |= (1 << IMU_NOTIFY_SHFITS);
             __HAL_GPIO_EXTI_GENERATE_SWIT(GPIO_PIN_0);
         }
     }

--- a/19.gimbal_task/application/INS_task.h
+++ b/19.gimbal_task/application/INS_task.h
@@ -33,7 +33,8 @@
 
 #define IMU_DR_SHFITS        0
 #define IMU_SPI_SHFITS       1
-#define IMU_UPDATE_SHFITS        2
+#define IMU_UPDATE_SHFITS    2
+#define IMU_NOTIFY_SHFITS    3
 
 
 #define BMI088_GYRO_RX_BUF_DATA_OFFSET  1

--- a/20.standard_robot/application/INS_task.c
+++ b/20.standard_robot/application/INS_task.c
@@ -222,9 +222,9 @@ void INS_task(void const *pvParameters)
         }
 
 
-        if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
+        if(gyro_update_flag & (1 << IMU_NOTIFY_SHFITS))
         {
-            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag &= ~(1 << IMU_NOTIFY_SHFITS);
             BMI088_gyro_read_over(gyro_dma_rx_buf + BMI088_GYRO_RX_BUF_DATA_OFFSET, bmi088_real_data.gyro);
         }
 
@@ -646,6 +646,8 @@ void DMA2_Stream2_IRQHandler(void)
 
         if(gyro_update_flag & (1 << IMU_UPDATE_SHFITS))
         {
+            gyro_update_flag &= ~(1 << IMU_UPDATE_SHFITS);
+            gyro_update_flag |= (1 << IMU_NOTIFY_SHFITS);
             __HAL_GPIO_EXTI_GENERATE_SWIT(GPIO_PIN_0);
         }
     }

--- a/20.standard_robot/application/INS_task.h
+++ b/20.standard_robot/application/INS_task.h
@@ -33,7 +33,8 @@
 
 #define IMU_DR_SHFITS        0
 #define IMU_SPI_SHFITS       1
-#define IMU_UPDATE_SHFITS        2
+#define IMU_UPDATE_SHFITS    2
+#define IMU_NOTIFY_SHFITS    3
 
 
 #define BMI088_GYRO_RX_BUF_DATA_OFFSET  1


### PR DESCRIPTION
修复INS_task中状态机问题，原状态机或会导致任务被唤醒但来不及清状态位时，被其他中断（加速度计、温感）再次唤醒，导致姿态解算被多次调用，结果产生偏差.